### PR TITLE
Implement watchdog app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Copyright Author name here (c) 2017
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# watchdog
+
+Utility for PC auto-restart. The app listens for signals
+on given TCP port and if nothing comes for specified amount of time
+it executes reboot-command.
+
+The invocation:
+
+~~~
+watchdog --conf config.yaml
+~~~
+
+Example of the typical config:
+
+~~~yaml
+server:
+  host: "localhost"
+  port: 8080
+duration: 10 # seconds
+rebootCmd: "echo REBOOT ME"
+lastRebootTimeFilePath: "reboot-log.txt"  # optional
+debugMode: true                           # optional (false by default)
+~~~
+
+The app listens for packets on TCP-socked specified in field `server`.
+For `duration` seconds it waits for the packets. If nothing happens
+it executes `rebootCmd`.
+
+Optionally we can specify file `lastRebootTimeFilePath` to log
+the last rebootCmd invocation time. If `debugMode` is set then
+the command is not performed immediately but delayed by 10 seconds so that
+user has choice to abort the reboot with Ctrl+C.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # watchdog
 
-Utility for PC auto-restart. The app listens for signals
+Utility for PC auto-restart. The app listens for UNIX signals or messages
 on given TCP port and if nothing comes for specified amount of time
 it executes reboot-command.
 
@@ -13,9 +13,10 @@ watchdog --conf config.yaml
 Example of the typical config:
 
 ~~~yaml
-server:
+server:                                   # optional
   host: "localhost"
   port: 8080
+signal: SIGUSR1                           # optional
 duration: 10 # seconds
 rebootCmd: "echo REBOOT ME"
 lastRebootTimeFilePath: "reboot-log.txt"  # optional
@@ -24,9 +25,37 @@ debugMode: true                           # optional (false by default)
 
 The app listens for packets on TCP-socked specified in field `server`.
 For `duration` seconds it waits for the packets. If nothing happens
-it executes `rebootCmd`.
+it executes `rebootCmd`. Also app can wait for unix signal specified in
+the field signal. Note that both fields `server` and `signal` are optional.
+If we need signals we can activate only signal section.
+For TCP-only usage just omit the `signal` field.
 
 Optionally we can specify file `lastRebootTimeFilePath` to log
 the last rebootCmd invocation time. If `debugMode` is set then
 the command is not performed immediately but delayed by 10 seconds so that
 user has choice to abort the reboot with Ctrl+C.
+
+### Test scenario
+
+Start first terminal with example config:
+
+~~~
+watchdog --conf config,yaml
+~~~
+
+**For TCP**:
+
+It will not reboot while we invoke in the second terminal:
+
+~~~
+echo 1 | netcat localhost 8080
+~~~
+
+
+**For UNIX signals**:
+
+It will not reboot while we invoke in the second terminal:
+
+~~~
+pkill --signal USR1 watchdog
+~~~

--- a/README.md
+++ b/README.md
@@ -59,3 +59,23 @@ It will not reboot while we invoke in the second terminal:
 ~~~
 pkill --signal USR1 watchdog
 ~~~
+
+
+### Example for systemd service script
+
+Supply needed path to app and config file and put this
+file to `/etc/systemd/system/` to define systemd service.
+
+~~~
+# location: /etc/systemd/system/
+[Unit]
+Description=Auto-restart utility
+After=multi-user.target
+
+[Service]
+Type=notify
+ExecStart=/path/to/watchdog --conf /path/to/config.yaml &
+
+[Install]
+WantedBy=multi-user.target
+~~~

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,0 +1,27 @@
+module Config(
+    Config(..)
+  , ServerConfig(..)
+) where
+
+import Data.Data
+import Data.Time
+import Data.Text (Text)
+import GHC.Generics
+
+import System.ConfigApp
+
+data Config = Config {
+    appServer   :: ServerConfig
+  , appDuration :: NominalDiffTime
+  , appRebootCmd :: Text
+  , appLastRebootTimeFilePath :: Maybe ConfigPath
+  , appDebugMode :: Maybe Bool
+} deriving (Show, Eq, Generic, Data)
+
+data ServerConfig = ServerConfig {
+    serverHost :: Text
+  , serverPort :: Int
+} deriving (Show, Eq, Generic, Data)
+
+$(deriveFromJSON defaultOptions ''ServerConfig)
+$(deriveFromJSON defaultOptions ''Config)

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -11,7 +11,8 @@ import GHC.Generics
 import System.ConfigApp
 
 data Config = Config {
-    appServer   :: ServerConfig
+    appServer   :: Maybe ServerConfig
+  , appSignal   :: Maybe String
   , appDuration :: NominalDiffTime
   , appRebootCmd :: Text
   , appLastRebootTimeFilePath :: Maybe ConfigPath

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,75 @@
+module Main where
+
+import Control.Concurrent
+import Control.Monad
+import Data.Maybe
+import Network.Simple.TCP
+import System.Directory
+import System.ConfigApp
+import Text.InterpolatedString.Perl6 (qc)
+
+import qualified Data.Text as T
+
+import Config
+import Utils
+import Reboot
+import TimeVar
+
+main :: IO ()
+main = configApp desc runConfig
+  where
+    desc = AppDesc
+      { appName = "watchdog"
+      , appDesc = "Restarts PC if no signal is sent over TCP" }
+
+runConfig :: Config -> IO ()
+runConfig cfg = checkConfig cfg $ do
+  tv <- initTimeVar
+  runTcpListener  cfg tv
+  runRebootWorker cfg tv
+  waitForever
+
+checkConfig :: Config -> IO () -> IO ()
+checkConfig cfg proc = do
+  let mLogFile = fmap unConfigPath $ appLastRebootTimeFilePath cfg
+  case mLogFile of
+    Just logFile -> do
+      isExist <- doesFileExist logFile
+      if isExist
+        then proc
+        else error $ logFileNonExistMsg logFile
+    Nothing -> proc
+  where
+    logFileNonExistMsg file = [qc|Error: Log file {file} does not exist.
+Check config field lastRebootTimeFilePath|]
+
+runTcpListener :: Config -> TimeVar -> IO ()
+runTcpListener cfg tv = void $ forkIO $ do
+  serve host port $ \(connectionSocket, remoteAddr) -> do
+    resp <- recv connectionSocket 1
+    when (isJust resp) $ do
+      updateTime tv
+  where
+    serverCfg = appServer cfg
+    host = Host $ T.unpack $ serverHost serverCfg
+    port = show $ serverPort serverCfg
+
+
+runRebootWorker :: Config -> TimeVar -> IO ()
+runRebootWorker cfg tv = runTimeCheckWorker cfg tv (reboot cfg)
+
+runTimeCheckWorker :: Config -> TimeVar -> (IO ()) -> IO ()
+runTimeCheckWorker cfg tv proc = void $ forkIO $ loop
+  where
+    totalDuration = appDuration cfg
+
+    loop = do
+      sleep totalDuration
+      isOk <- checkTime tv
+      if isOk
+        then loop
+        else do
+          proc
+          loop
+
+    checkTime tv =  fmap ( < totalDuration) $ timePassed tv

--- a/app/Reboot.hs
+++ b/app/Reboot.hs
@@ -1,0 +1,45 @@
+module Reboot(
+  reboot
+) where
+
+import Control.Monad
+import Control.Exception
+import Data.Time
+import Text.InterpolatedString.Perl6 (qc)
+import Text.Read
+import qualified Data.Text as T
+
+import System.ConfigApp
+import System.Process
+
+import Config
+import Utils
+
+reboot :: Config -> IO ()
+reboot config = do
+  when isDebug $ do
+    mapM_ (\file -> maybe (return ()) print =<< getLastRebootTime file) mLogFile
+    putStrLn "PC will be restarted in 10 seconds."
+    putStrLn "Type Ctrl+C to cancel reboot."
+    sleep 10
+  mapM_ (\file -> (putLastRebootTime file) =<< getCurrentTime) mLogFile
+  void $ system (T.unpack $ appRebootCmd config)
+  where
+    isDebug = maybe False id $ appDebugMode config
+    mLogFile = fmap unConfigPath $ appLastRebootTimeFilePath config
+
+putLastRebootTime :: FilePath -> UTCTime -> IO ()
+putLastRebootTime filename time = do
+  ewriteResult <- try $ writeFile filename $ show time
+  case ewriteResult of
+    Left (except :: IOError) -> putStrLn [qc|Error writing file {filename}: {except}|] >> return ()
+    _ -> return ()
+
+getLastRebootTime :: FilePath -> IO (Maybe UTCTime)
+getLastRebootTime filename = do
+  econtents <- try $ readFile filename
+  case econtents of
+    Left (except :: IOError) -> putStrLn [qc|Error reading file {filename}: {except}|] >> return Nothing
+    Right contents -> pure $ readMaybe contents
+
+

--- a/app/Signal.hs
+++ b/app/Signal.hs
@@ -1,0 +1,51 @@
+module Signal(
+    parseSignal
+  , initSignalHandler
+) where
+
+import Control.Monad
+
+import Data.Char
+import System.Posix.Signals
+
+import qualified Data.List as L
+
+initSignalHandler :: Signal -> IO () -> IO ()
+initSignalHandler sig proc =
+  void $ installHandler sig (Catch proc) Nothing
+
+parseSignal :: String -> Maybe Signal
+parseSignal str =
+  case removeSigPrefix $ fmap toLower str of
+    "abrt" -> Just sigABRT
+    "alrm" -> Just sigALRM
+    "fpe" -> Just sigFPE
+    "hup" -> Just sigHUP
+    "ill" -> Just sigILL
+    "int" -> Just sigINT
+    "kill" -> Just sigKILL
+    "pipe" -> Just sigPIPE
+    "quit" -> Just sigQUIT
+    "segv" -> Just sigSEGV
+    "term" -> Just sigTERM
+    "usr1" -> Just sigUSR1
+    "usr2" -> Just sigUSR2
+    "chld" -> Just sigCHLD
+    "cont" -> Just sigCONT
+    "stop" -> Just sigSTOP
+    "tstp" -> Just sigTSTP
+    "ttin" -> Just sigTTIN
+    "ttou" -> Just sigTTOU
+    "bus" -> Just sigBUS
+    "poll" -> Just sigPOLL
+    "prof" -> Just sigPROF
+    "sys" -> Just sigSYS
+    "trap" -> Just sigTRAP
+    "urg" -> Just sigURG
+    "vtalrm" -> Just sigVTALRM
+    "xcpu" -> Just sigXCPU
+    "xfsz" -> Just sigXFSZ
+    _ -> Nothing
+  where
+    removeSigPrefix x = maybe x id $ L.stripPrefix "sig" x
+

--- a/app/TimeVar.hs
+++ b/app/TimeVar.hs
@@ -1,0 +1,24 @@
+module TimeVar(
+    TimeVar
+  , initTimeVar
+  , timePassed
+  , updateTime
+) where
+
+import Control.Concurrent.STM
+import Control.Concurrent.STM.TVar
+import Data.Time
+
+newtype TimeVar = TimeVar { unTimeVar :: TVar UTCTime }
+
+initTimeVar :: IO TimeVar
+initTimeVar = fmap TimeVar $ newTVarIO =<< getCurrentTime
+
+timePassed :: TimeVar -> IO NominalDiffTime
+timePassed (TimeVar tv) = do
+  lastTimePing <- readTVarIO tv
+  timeNow <- getCurrentTime
+  return $ diffUTCTime timeNow lastTimePing
+
+updateTime :: TimeVar -> IO ()
+updateTime (TimeVar tv) = atomically . writeTVar tv =<< getCurrentTime

--- a/app/Utils.hs
+++ b/app/Utils.hs
@@ -1,0 +1,24 @@
+module Utils(
+    sleep
+  , waitForever
+) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Thread.Delay
+import Control.Monad
+import Control.Monad.IO.Class
+
+import Data.Time
+
+-- | Stop the thread for some time.
+sleep :: MonadIO m => NominalDiffTime -> m ()
+sleep dt = liftIO . delay $ toMicroseconds dt
+
+-- | Convert time to microseconds
+toMicroseconds :: NominalDiffTime -> Integer
+toMicroseconds t = ceiling $ toRational t * 1000000
+
+-- | Stop the thread forever
+waitForever :: IO ()
+waitForever = do
+  forever $ threadDelay maxBound

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 server:
   host: "localhost"
   port: 8080
+signal: SIGUSR1
 duration: 10
 rebootCmd: "echo REBOOT ME"
 # lastRebootTimeFilePath: "reboot-log.txt"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+server:
+  host: "localhost"
+  port: 8080
+duration: 10
+rebootCmd: "echo REBOOT ME"
+# lastRebootTimeFilePath: "reboot-log.txt"
+debugMode: true

--- a/config.yaml
+++ b/config.yaml
@@ -5,4 +5,4 @@ signal: SIGUSR1
 duration: 10
 rebootCmd: "echo REBOOT ME"
 # lastRebootTimeFilePath: "reboot-log.txt"
-debugMode: true
+# debugMode: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,19 @@
+resolver: lts-9.13
+
+packages:
+- .
+- location:
+    git: git@github.com:hexresearch/config-app.git
+    commit: a23131b
+  extra-dep: true
+
+# Dependency packages to be pulled from upstream that are not in the resolver
+# (e.g., acme-missiles-0.3)
+extra-deps:
+- concurrent-extra-0.7.0.11
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"

--- a/watchdog.cabal
+++ b/watchdog.cabal
@@ -1,0 +1,58 @@
+name:                watchdog
+version:             0.1.0.0
+synopsis:            PC auto-restart utility
+description:         Utility for PC auto-restart. The app listens for signals
+                     on given TCP port and if nothing comes for specified amount of time
+                     it executes reboot-command.
+homepage:            https://github.com/githubuser/watchdog#readme
+license:             BSD3
+license-file:        LICENSE
+author:              HEX Research
+maintainer:          example@example.com
+copyright:           2017 HEX Research
+category:            Web
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+executable watchdog
+  hs-source-dirs:      app
+  main-is:             Main.hs
+  other-modules:       Config
+                       Reboot
+                       TimeVar
+                       Utils
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , concurrent-extra
+                     , config-app
+                     , directory
+                     , interpolatedstring-perl6
+                     , mtl
+                     , network-simple
+                     , process
+                     , stm
+                     , time
+                     , text
+                     , unbounded-delays
+  default-language:    Haskell2010
+  default-extensions:
+    DeriveDataTypeable
+    DeriveGeneric
+    OverloadedStrings
+    QuasiQuotes
+    ScopedTypeVariables
+    TemplateHaskell
+
+test-suite watchdog-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , watchdog
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/githubuser/watchdog

--- a/watchdog.cabal
+++ b/watchdog.cabal
@@ -20,6 +20,7 @@ executable watchdog
   main-is:             Main.hs
   other-modules:       Config
                        Reboot
+                       Signal
                        TimeVar
                        Utils
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
@@ -35,6 +36,7 @@ executable watchdog
                      , time
                      , text
                      , unbounded-delays
+                     , unix
   default-language:    Haskell2010
   default-extensions:
     DeriveDataTypeable


### PR DESCRIPTION
Реализация вочдога, по мотивам того что было у нас в hexbwmeter.
Описание в [README](https://github.com/hexresearch/watchdog/blob/implement-app/README.md)

Для проверки после сборки можно запустить вочдог с примеом конфига:

~~~
watchdog --conf config,yaml
~~~

После этог выполнить в другом терминале:

~~~
echo 1 | netcat localhost 8080
~~~

Убедиться, что вочдог "висит" пока мы повторяем выполнение команды.
Потом, если не выполнить эту команду и подождать 10 секунд,
то вочдог выполнит команду перезагрузки из конфига.

Для примера это просто эхо печать REBOOT ME, на практике там
будет реальная команда перезагрузки, вроде `sudo reboot`.


